### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo 'deb http://ftp.de.debian.org/debian jessie-backports main' >> /etc/apt
     apt-get clean && \
     apt-get update && \
     apt-get install -y build-essential git && \
-    apt-get -y install openjdk-8-jdk && \
+    apt-get -y install -t jessie-backports openjdk-8-jdk ca-certificates-java && \
     update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
     bundle && \
     apt-get remove -y build-essential git


### PR DESCRIPTION
use Debian Jesse backports to bypass ca error. ([stackoverflow explanation](https://unix.stackexchange.com/questions/342403/openjdk-8-jre-headless-depends-ca-certificates-java-but-it-is-not-going-to-be))

Resolves https://github.com/sivakumar-kailasam/codeclimate-checkstyle/pull/5#issuecomment-283671912

//cc @maxjacobson