### PR TITLE
Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: Push image to Dockerhub
           command: |
             make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
-            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+' || echo stable)"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,12 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag codeclimate/codeclimate-checkstyle \
-              us.gcr.io/code-climate/codeclimate-checkstyle:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-checkstyle:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: Push image to Dockerhub
           command: |
             make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
-            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+' || echo stable)"
 
 workflows:
   version: 2
@@ -38,6 +38,7 @@ workflows:
     jobs:
       - test
       - release_images:
+          context: Quality
           requires:
             - test
           filters:

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ upgrade:
 	$(DOCKER_RUN_MOUNTED) $(IMAGE_NAME) ./bin/scrape-docs
 
 release:
-	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-bundler-audit:$(RELEASE_TAG)
-	docker push $(RELEASE_REGISTRY)/codeclimate-bundler-audit:$(RELEASE_TAG)
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-checkstyle:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-checkstyle:$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-checkstyle
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
 DOCKER_RUN_MOUNTED = docker run --rm --user=root -w /usr/src/app -v $(PWD):/usr/src/app
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: image test
+.PHONY: image test release
 
 IMAGE_NAME ?= codeclimate/codeclimate-checkstyle
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 DOCKER_RUN_MOUNTED = docker run --rm --user=root -w /usr/src/app -v $(PWD):/usr/src/app
 
 image:
@@ -15,3 +17,7 @@ test: image
 upgrade:
 	$(DOCKER_RUN_MOUNTED) $(IMAGE_NAME) ./bin/upgrade.sh
 	$(DOCKER_RUN_MOUNTED) $(IMAGE_NAME) ./bin/scrape-docs
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-bundler-audit:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-bundler-audit:$(RELEASE_TAG)


### PR DESCRIPTION
Push images to Dockerhub instead of GCR

- For `master` branch:
    - push image `codeclimate-checkstyle:bXXX`
    - push image `codeclimate-checkstyle:latest`
- For `channel/channel-name` branches:
    - push image `codeclimate-checkstyle:bXXX`
    - push image `codeclimate-checkstyle:channel-name`